### PR TITLE
For the download from the OR menu: Added .git to the url in 3 places. Added some sizes.

### DIFF
--- a/routes.json
+++ b/routes.json
@@ -37,7 +37,8 @@
             "url": "https://github.com/DocMartin7644"
         },
         "image": "https://raw.githubusercontent.com/DocMartin7644/Chiltern-Route-v2/main/Screenshot.jpg",
-        "url": "https://github.com/DocMartin7644/Chiltern-Route-v2"
+        "url": "https://github.com/DocMartin7644/Chiltern-Route-v2.git",
+        "installSize": 13227601920
     },
     {
         "@type": "https://schema.org/SoftwareApplication",
@@ -63,7 +64,9 @@
             "name": "Making Tracks Ltd"
         },
         "image": "https://www.openrails.org/assets/waverley.jpg",
-        "url": "http://static.openrails.org/files/DemoModel1.zip"
+        "url": "http://static.openrails.org/files/DemoModel1.zip",
+        "downloadSize": 253648896,
+        "installSize": 311382016
     },
     {
         "@type": "https://schema.org/SoftwareApplication",
@@ -102,7 +105,8 @@
             "name": "Mick Clarke"
         },
         "image": "https://raw.githubusercontent.com/MECoast/MECoast/main/GitHub_assets/Spilsby.jpg",
-        "url": "https://github.com/MECoast/MECoast"
+        "url": "https://github.com/MECoast/MECoast.git",
+        "installSize": 8290103296
     },
     {
         "@type": "https://schema.org/SoftwareApplication",
@@ -128,7 +132,8 @@
             "url": "https://github.com/rickloader"
         },
         "image": "https://raw.githubusercontent.com/rickloader/NewForestRouteV3/main/NfGit.jpg",
-        "url": "https://github.com/rickloader/NewForestRouteV3"
+        "url": "https://github.com/rickloader/NewForestRouteV3.git",
+        "installSize": 23941709824
     },
     {
         "@type": "https://schema.org/SoftwareApplication",


### PR DESCRIPTION
I don't think that adding the .git interferes with the website which is using this URL. With the URL ending in .zip and .git I can distinguish between the different download methods. The route URLs without these I just skip. 

I see also routes with an executable as the means to install the route. That looks to be not usable. As a User Interface would pop up after starting the .exe. Besides the risk of viruses. 

I'm missing the Portuguese route OR CPV. Can I add that one or do you ask the owners for permission?