### PR TITLE
HTTP -> HTTPS

### DIFF
--- a/routes.json
+++ b/routes.json
@@ -70,7 +70,7 @@
             "name": "Making Tracks Ltd"
         },
         "image": "https://www.openrails.org/assets/waverley.jpg",
-        "url": "http://static.openrails.org/files/DemoModel1.zip",
+        "url": "https://static.openrails.org/files/DemoModel1.zip",
         "downloadSize": 253648896,
         "installSize": 311382016,
         "start": {


### PR DESCRIPTION
Missing "S" leads to browser warning