### PR TITLE
use new domain and change to HTTPS

### DIFF
--- a/routes.json
+++ b/routes.json
@@ -12,8 +12,8 @@
         "image": "https://raw.githubusercontent.com/openrails/content/main/images/TrainSimulations.net/BNSF_starter_route.jpg",
         "screenshot": "https://www.trainsimulations.net/starter",
         "url": "https://ts-files.com/files/TS_STARTER_ROUTE.zip",
-        "downloadSize": 428811336,
-        "installSize": 521159055
+        "downloadSize": 598168814,
+        "installSize": 894345725
     },
     {
         "@type": "https://schema.org/SoftwareApplication",

--- a/routes.json
+++ b/routes.json
@@ -11,7 +11,7 @@
         },
         "image": "https://raw.githubusercontent.com/openrails/content/main/images/TrainSimulations.net/BNSF_starter_route.jpg",
         "screenshot": "https://www.trainsimulations.net/starter",
-        "url": "https://files.trainsimulations.net/TS_STARTER_ROUTE.zip",
+        "url": "https://ts-files.com/files/TS_STARTER_ROUTE.zip",
         "downloadSize": 428811336,
         "installSize": 521159055
     },
@@ -23,11 +23,11 @@
         "author": {
             "@type": "https://schema.org/Person",
             "name": "Peter Newell",
-            "url": "http://coalstonewcastle.com.au"
+            "url": "https://coalstonewcastle.com.au"
         },
-        "image": "http://www.burrinjuck.coalstonewcastle.com.au/screenshots/images/001-image.jpg",
-        "screenshot": "http://www.burrinjuck.coalstonewcastle.com.au/screenshots/",
-        "url": "http://www.burrinjuck.coalstonewcastle.com.au/",
+        "image": "https://www.burrinjuck.coalstonewcastle.com.au/screenshots/images/001-image.jpg",
+        "screenshot": "https://www.burrinjuck.coalstonewcastle.com.au/screenshots/",
+        "url": "https://www.burrinjuck.coalstonewcastle.com.au/",
         "downloadSize": 136713223
     },
     {


### PR DESCRIPTION
TrainSimulations.Net has a new domain for their files.
CoalsToNewcastle now supports HTTPS.